### PR TITLE
Some improvements to match z.sh's behaviour

### DIFF
--- a/z.psm1
+++ b/z.psm1
@@ -126,9 +126,32 @@ function Update-NavigationHistory {
 		# TODO: Append only one item instead of rewriting the whole file?
 	}
 
-	# TODO: Age the complete database if the compound score is above 1000
-	#$navdb | Measure-Object -Sum Frequency
-	#if ($navdb.Count -gt 1000) {}
+	# Filter out all directories that don't exist
+	$total = 0
+	[Array]$newdb = @()
+
+	foreach ($item in $navdb) {
+		if (Test-path $item.Path) {
+			$newdb += $item
+			$total += $item.Frequency
+		}
+	}
+
+	$navdb = $newdb
+	
+	# Age the complete database if the compound score is above 1000
+	if ($total -gt 1000) {
+		$newdb = @()
+		foreach ($item in $navdb) {
+			[double]$freq = [double]$item.Frequency
+			[Int64]$newf = [math]::floor($freq * 0.9)
+			if ($newf -gt 0) {
+				[Int64]$item.Frequency = [Int64]$newf
+				$newdb += $item
+			}
+		}
+		$navdb = $newdb
+	}
 
 	# Save database
 	try {
@@ -137,6 +160,7 @@ function Update-NavigationHistory {
 		Write-Output $_.Exception.Message
 	}
 }
+
 
 function Search-NavigationHistory {
 	Param(

--- a/z.psm1
+++ b/z.psm1
@@ -36,12 +36,6 @@ function Calculate-FrecencyValue {
 function MatchAll-Patterns {
 	Param([String]$string, [Array][String]$patterns)
 	
-	# foreach ($pattern in $patterns) {
-	# 	if ($string -inotmatch $pattern) {
-	# 		return $false
-	# 	}
-	# }
-
 	$teststring = $string
 
 	foreach ($pattern in $patterns) {

--- a/z.psm1
+++ b/z.psm1
@@ -31,17 +31,19 @@ function Calculate-FrecencyValue {
 function MatchAll-Patterns {
 	Param([String]$string, [Array][String]$patterns)
 	
-	$lastpos = -1
+	# foreach ($pattern in $patterns) {
+	# 	if ($string -inotmatch $pattern) {
+	# 		return $false
+	# 	}
+	# }
+
+	$teststring = $string
+
 	foreach ($pattern in $patterns) {
-		$match = [regex]::Match($string, $pattern, 
-				[System.StringComparison]::OrdinalIgnoreCase)
-		if ($Match.Success) {
-			$index = $Match.Index
-			if ($index -gt $lastpos) {
-				$lastpos = $index
-			}	else {
-				return $false
-			}
+		if ($teststring -imatch $pattern) {
+			$index = $teststring.IndexOf($matches[0])
+			$size = $matches[0].length
+			$teststring = $teststring.Substring($index + $size)
 		}	else {
 			return $false
 		}

--- a/z.psm1
+++ b/z.psm1
@@ -185,6 +185,19 @@ function Search-NavigationHistory {
 		[Array]$PatternList = $Patterns.Split()
 	}
 
+	# Jump directly for a existing path name
+    if (($PatternList.Count -eq 1) -and (-Not $List)) {
+		if ($PatternList[0] -eq '-') {
+			Pop-Location
+			return
+		}
+		if (Test-path $PatternList[0]) {
+			Set-Location $PatternList[0]
+			return
+		}
+	}
+
+
 	# Import database
 	try {
 		[Array]$navdb = Import-Csv $dbfile -Encoding 'Unicode'

--- a/z.psm1
+++ b/z.psm1
@@ -152,7 +152,8 @@ function Search-NavigationHistory {
 	try {
 		[Array]$navdb = Import-Csv $dbfile -Encoding 'Unicode'
 	} catch [System.IO.FileNotFoundException] {
-		$_.Exception.Message
+		# $_.Exception.Message
+		""
 		return
 	}
 	$navdb | Add-Member -MemberType NoteProperty -Name 'Rank' -Value 0

--- a/z.psm1
+++ b/z.psm1
@@ -31,11 +31,22 @@ function Calculate-FrecencyValue {
 function MatchAll-Patterns {
 	Param([String]$string, [Array][String]$patterns)
 	
+	$lastpos = -1
 	foreach ($pattern in $patterns) {
-		if ($string -inotmatch $pattern) {
+		$match = [regex]::Match($string, $pattern, 
+				[System.StringComparison]::OrdinalIgnoreCase)
+		if ($Match.Success) {
+			$index = $Match.Index
+			if ($index -gt $lastpos) {
+				$lastpos = $index
+			}	else {
+				return $false
+			}
+		}	else {
 			return $false
 		}
 	}
+
 	return $true
 }
 
@@ -193,3 +204,6 @@ function Search-NavigationHistory {
 		Set-Location $winner.Path
 	}
 }
+
+
+

--- a/z.psm1
+++ b/z.psm1
@@ -2,7 +2,7 @@
 # PowerShell port of z.sh
 #
 
-$dbfile = "$env:UserProfile\navdb.csv"
+$dbfile = "$env:UserProfile\.navdb.csv"
 
 # Tip:
 # You should combine this script with "Push-Location" and "Pop-Location"


### PR DESCRIPTION
Having been using rupa's famous [z.sh](https://github.com/rupa/z) under linux for years, thanks for z.ps, because I can use the same z on Windows now. 

And I also like to contribute some improvement to make it stronger

1. Filter out all directories that don't exist
2. Age the complete database if compound score is above 1000
3. Matches patterns in order (that exactly z.sh does)
4. Ignore warning message if navdb doesn't exist
5. Prefix navdb.csv a dot: not easy to be deleted by mistake
6. Jump directly for a existing path name (z.sh does this)

Thanks